### PR TITLE
[#7] Update docs: features, typos, caveats, more notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Unix_ (2010) on Hacker News.
 
 ## Features
 
-Type in APL on mobile. Receive a toast with the ASCII equivalent. Through play,
+Type in APL on mobile. Receive info about the symbol. Through play,
 learn passively various ideas and operations that could filter into your daily
 (other) programming languages. Spark curiosity.
 
@@ -66,13 +66,20 @@ Admittedly, this only touches the surface of starting out with APL. We only
 assigned one APL symbol (alpha), and use `?` for testing purposes. Further work
 will be done here to separate the keycode mapping elsewhere for tidiness.
 
+Because we take over Left Control + Left Alt, we can't cycle consoles with the
+Function keys (F1-F5, for example). This seems okay since we shouldn't be
+switching to root too often.
+
+Right Alt + Caps Lock is an ISO_Level_3_Shift, which is an escape route in case
+of needing additional Unicode characters (maybe?).
+
 ## Verifying APL Symbol Setup
 
 Here are a few test cases to try after launching with `startx`; first, we verify
 Compose key works:
 
 1. Press Shift and Right Alt.
-2. Type tilde ```
+2. Type backtick (grave) key.
 3. Type `a`
 
 The terminal should produce accented a.
@@ -101,7 +108,7 @@ development feedback loop to debug key mappings.
 ## Pattern Notes
 
 Reviewing the Unicode characters for APL, the modifiers look to be quad, stile,
-tilde, diaresis (double-quote), macron (overbar), circle, slash, backslash, jot,
-minus, and down tack. (More details to be shared in a table later, once key
-mappings are complete.)
+underbar, tilde, diaresis (double-quote), macron (overbar), circle, slash,
+backslash, jot, minus, and down tack. (More details to be shared in a table
+later, once key mappings are complete.)
 


### PR DESCRIPTION
Reviewing the README, found several things to change. First, since we're going all-in with Unicode, there's not going to be--or possibly even a real feature in APL--for ASCII-equivalent symbols. I think because even something like `/\` to mean (logical AND) "up caret" is going to be hard Fundamentally, human vision sees two characters.

We also want to note that Left Control + Left Alt means no more easily switching to a console (F2 or thereabouts) for root operations. This is minor friction, and welcome, since it's bad practice anyway.

We also note Right Alt + Caps is an ISO_Level_3_Shift, which int'l folks may understand. For us, it's an escape valve to avoid locking ourselves in, in case we need to map even more mystery characters. This early on, with very little knowledge, it's all about options, options, options.

Noted to press backtick (or grave) instead of tilde, since asciitilde is really Shift + backtick, and that could be confusing: we don't press Shift at all; we just press the backtick key by itself.

Mentioned the underbar in patterns, so we ended up (happily) with a kind of ascending chorus: underscore, asciitilde, diaresis, and macron.

(#7)