### PR TITLE
[#11] Map initial APL symbols to standard keyboard keys

### DIFF
--- a/.Xmodmapapl
+++ b/.Xmodmapapl
@@ -1,0 +1,32 @@
+! .Xaplmodmap
+! Keycodes mapped to APL Unicode symbols
+
+! Generate your own with
+!
+!     tmux     # For scrolling
+!     xev -pke # Print keycodes to stdout
+!     # C-b [
+!     # PgUp or PgDown
+!
+
+! Keycode mappings
+!
+! 49 ` ~ ⋄   ⌺    DIAMOND             QUAD DIAMOND
+! 10 1 ! ¨       ⌶    DIAERESIS           I-BEAM
+! 11 2 @ ¯                       MACRON              ?
+! 12 3 # <              ⍒    LESS-THAN SIGN      DEL STILE
+! 13 4 $ ≤   ⍏    LESS-THAN OR EQUAL  UPWARDS VANE
+! 14 5 % =              ⌽    <equal>             CIRCLE STILE
+! 15 6 ^ ≥   ⍉    GREATER-THAN OR     CIRCLE SLOPE
+! 16 7 & >              ∘    GREATER-THAN        JOT
+
+keycode  49 = grave asciitilde U22c4 U233a
+keycode  10 = 1 exclam diaeresis U2336
+! can't find DEL OVERBAR
+keycode  11 = 2 at U00AF question
+keycode  12 = 3 numbersign U003C U2352
+keycode  13 = 4 dollar U2264 U234f
+! In APL mode (Ctrl+Alt), equals outputs division, so alt. equal still needed
+keycode  14 = 5 percent equal U233d
+keycode  15 = 6 asciicircum U2265 U2349
+keycode  16 = 7 ampersand U003E U2218

--- a/README.md
+++ b/README.md
@@ -60,11 +60,17 @@ these options:
     setxkbmap -option lv3:ralt_switch_multikey
     setxkbmap -option lv3:caps_switch_latch
     setxkbmap -option grp:ctrl_alt_toggle
-    xmodmap -e "keycode 38 = a A U237a question"
+    xmodmap $HOME/.Xmodmapapl
 
-Admittedly, this only touches the surface of starting out with APL. We only
-assigned one APL symbol (alpha), and use `?` for testing purposes. Further work
-will be done here to separate the keycode mapping elsewhere for tidiness.
+Next, copy the .Xmodmapapl file from this repo to your HOME directory.
+
+Finally, type `startx` to start X11 with the modified setup.
+
+Open an `xterm`, and press Left Control and Left Alt at the same time. Typing
+1 should print two upper dots, or a _diaeresis,_ and typing exclamation mark
+(Shift+1) should print a larger-looking "I" character (called an I-beam).
+
+Your APL input mode is enabled!
 
 Because we take over Left Control + Left Alt, we can't cycle consoles with the
 Function keys (F1-F5, for example). This seems okay since we shouldn't be


### PR DESCRIPTION
We add the start of some APL mappings to the keys

    ` ~, 1 !, 2 @, 3 #, 4 $, 5 %, 6 ^, and 7 &

For example, the first key (grave) and its shift (tilde) generate the
APL symbols diamond and quad diamond, respectively, with the Ctrl-Alt
toggle.

One convention we use is to use uppercase letters in the Unicode
code point when it is from /usr/X11R6/include/X11/keysymdef.h file;
otherwise, it is from the /usr/X11R6/share/X11/en_US.UTF-8/Compose file

With OpenBSD base vi, Unicode symbols are output as (so far) two or
three hex codes. That's a useful data point--or could be in the future-
-so we include a table for it. Otherwise, we `cat` the file to stdout
in xterm to see the hex codes "rendered" to the actual single symbol.

Sometimes vi does not print hex codes but an ASCII version of the
symbol. These are notable in that, even though a Unicode code point is
defined in the .Xmodmapapl file, the editor prints straight through of
the symbol (< or >, for example) instead of the _Unicode_ code point.

One symbol we could not find is DEL OVERBAR equivalent, or an
upside-down triangle (DEL) with macron above it. We leave that as a ?
question mark symbol for now.

Between editing the .Xmodmapapl file, one does need to exit out of X and
go back in with `startx` to refresh mappings. The Restart Fvwm from the
context menu didn't seem to reload the file. But when things aren't
working, exiting out lets us see if there were any issues loading the
dot file itself.

Using ed(1) with only these primitives

    x,yp  i|.|w  x  d  -x

is good practice. At least to get started on the other things. It's like
learning vi (again)! Or something.

(https://github.com/turtleyacht/ap-el-kb.github.io/issues/11)